### PR TITLE
comment out openjpa.InitializeEagerly=true

### DIFF
--- a/datamodel/src/main/resources/META-INF/persistence.xml
+++ b/datamodel/src/main/resources/META-INF/persistence.xml
@@ -19,7 +19,7 @@
  -->
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence 
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
 	http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
 	<persistence-unit name="cxfjpa" transaction-type="JTA">
 		<provider>org.apache.openjpa.persistence.PersistenceProviderImpl</provider>
@@ -36,7 +36,7 @@
 			<property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema(SchemaAction='add,deleteTableContents')" />
 			<property name="openjpa.jdbc.MappingDefaults" value="ForeignKeyDeleteAction=restrict,JoinForeignKeyDeleteAction=restrict"/>
 			<property name="openjpa.Multithreaded" value="false"/>
-			<property name="openjpa.InitializeEagerly" value="true"/>
+			<!--property name="openjpa.InitializeEagerly" value="true"/-->
 			<property name="openjpa.DynamicEnhancementAgent" value="false" />
 			<property name="openjpa.RuntimeUnenhancedClasses" value="unsupported" />
 			<property name="openjpa.jdbc.SchemaFactory" value="native(foreignKeys=true)" />


### PR DESCRIPTION
When doing a feature install on a fresh Fuse 6.1: `features:install distributedtx-jpa-example`

getting the below error:

> 16:09:07,759 | ERROR | rint Extender: 1 | BlueprintContainerImpl           | 9 - org.apache.aries.blueprint.core - 1.0.1.redhat-610379 | Unable to start blueprint container for bundle productconfig-persistence due to unresolved dependencies [(&(&(org.apache.aries.jpa.proxy.factory=true)(osgi.unit.name=productconfig))(objectClass=javax.persistence.EntityManagerFactory))]

Commenting out the  openjpa.InitializeEagerly property makes it work (See https://access.redhat.com/solutions/1178243).
